### PR TITLE
Update secrets handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,9 @@ Below are the sources it reads in order of least precendence.
  - a `config/common.json` JSON file in your project
  - a `config/NODE_ENV.json` JSON file in your project
  - a `config/secrets/secrets.json` JSON file in your project
- containing secrets (API keys, OAuth tokens, etc)
- - a `config/secrets-NODE_ENV.json` JSON file in your
- project containing secrets per NODE_ENV
+ containing secrets (API keys, OAuth tokens, etc) only for production
+ - a `config/secrets/secrets-NODE_ENV.json` JSON file in your
+ project containing secrets per NODE_ENV but not production
  - a `config/NODE_ENV.{datacenter}.json` JSON file in your
     project if you specificed a datacenter.
  - a `{ datacenter: '{datacenter}' }` literal if you 

--- a/get-config-state.js
+++ b/get-config-state.js
@@ -36,7 +36,7 @@ function getConfigState(dirname, opts) {
         cliArgs.config || null,
         // get datacenter from opts.dc file
         dc ? dc : null,
-        // load ./config/NODE_ENV.DATACENTER.json
+        // load ./config/secrets/NODE_ENV.DATACENTER.json
         dc && NODE_ENV ?
             join(configFolder, NODE_ENV + '.' + dc.datacenter + '.json') :
             null,

--- a/get-config-state.js
+++ b/get-config-state.js
@@ -40,10 +40,14 @@ function getConfigState(dirname, opts) {
         dc && NODE_ENV ?
             join(configFolder, NODE_ENV + '.' + dc.datacenter + '.json') :
             null,
-        // load ./config/secrets-NODE_ENV.json
-        NODE_ENV ? join(configFolder, 'secrets' + '-' + NODE_ENV + '.json') : null,
-        // load ./config/secrets/secrets.json
-        join(configFolder, 'secrets', 'secrets.json'),
+        // load ./config/secrets/secrets.json only in production
+        NODE_ENV === 'production' ?
+            join(configFolder, 'secrets', 'secrets.json') :
+            null,
+        // load ./config/secrets-NODE_ENV.json except in production
+        NODE_ENV !== 'production' ? 
+            join(configFolder, 'secrets', 'secrets' + '-' + NODE_ENV + '.json') :
+            null,
         // load ./config/NODE_ENV.json
         NODE_ENV ? join(configFolder, NODE_ENV + '.json') : null,
         // load ./config/common.json

--- a/get-config-state.js
+++ b/get-config-state.js
@@ -9,7 +9,7 @@ module.exports = getConfigState;
 function getConfigState(dirname, opts) {
     var cliArgs = parseArgs(opts.argv || process.argv.slice(2));
     var env = opts.env || process.env;
-    var NODE_ENV = env.NODE_ENV;
+    var NODE_ENV = (env.NODE_ENV) ? env.NODE_ENV.toLowerCase() : null;
     var dc = opts.datacenterValue;
     var blackList = opts.blackList || ['_'];
 

--- a/test/index.js
+++ b/test/index.js
@@ -90,18 +90,20 @@ test('config loads config files', withFixtures(__dirname, {
     assert.equal(config.get('nested.extra'), 40);
     assert.equal(config.get('someKey'), 'ok');
     assert.equal(config.get('freeKey'), 'nice');
-    assert.equal(config.get('awsKey'), 'ABC123DEF');
+    assert.notEqual(config.get('awsKey'), 'ABC123DEF');
 
     var conf = config.get();
     assert.equal(conf.someKey, 'ok');
     assert.equal(conf.freeKey, 'nice');
     assert.equal(conf.port, 4000);
-    assert.equal(conf.awsKey, 'ABC123DEF');
+    assert.notEqual(conf.awsKey, 'ABC123DEF');
     assert.deepEqual(conf.nested, {
         key: true,
         shadowed: ':)',
         extra: 40
     });
+    
+
 
     assert.end();
 }));
@@ -127,11 +129,11 @@ test('env config files take presidence', withFixtures(__dirname, {
         secrets : {
             'secrets.json': JSON.stringify({
                 awsKey: 'ABC123DEF'
+            }),
+            'secrets-test.json': JSON.stringify({
+                awsKey: 'ZYX098WVU'
             })
         },
-        'secrets-test.json': JSON.stringify({
-            awsKey: 'ZYX098WVU'
-        })
     }
 }, function (assert) {
     var env = {
@@ -143,6 +145,16 @@ test('env config files take presidence', withFixtures(__dirname, {
 
     var conf = config.get();
     assert.equal(conf.awsKey, 'ZYX098WVU');
+
+    //reset to production
+    env = {
+        'NODE_ENV': 'production'
+    };
+
+    config = fetchConfig(__dirname, { env: env, dcValue: 'peak1'});
+    assert.equal(config.get('awsKey'), 'ABC123DEF');
+    conf = config.get();
+    assert.equal(conf.awsKey, 'ABC123DEF');
 
     assert.end();
 }));

--- a/test/index.js
+++ b/test/index.js
@@ -108,6 +108,43 @@ test('config loads config files', withFixtures(__dirname, {
     assert.end();
 }));
 
+test('env case gets normalized', withFixtures(__dirname, {
+    config: {
+        secrets: {
+            'secrets.json': JSON.stringify({
+                awsKey: 'abc123'
+            }),
+            'secrets-TEST': JSON.stringify({
+                awsKey: 'def456'
+            })
+        }
+    }
+}, function (assert) {
+    var env = {
+        'NODE_ENV': 'PRODUCTION'
+    };
+
+    var config = fetchConfig(__dirname, { env: env , dcValue: 'peak1'});
+
+    assert.equal(config.get('awsKey'), 'abc123');
+
+    var conf = config.get();
+    assert.equal(conf.awsKey, 'abc123');
+
+    env = {
+        'NODE_ENV': 'production'
+    };
+
+    config = fetchConfig(__dirname, { env: env , dcValue: 'peak1'});
+
+    assert.equal(config.get('awsKey'), 'abc123');
+
+    conf = config.get();
+    assert.equal(conf.awsKey, 'abc123');
+
+    assert.end();
+}));
+
 test('env config files take presidence', withFixtures(__dirname, {
     config: {
         'common.json': JSON.stringify({


### PR DESCRIPTION
This PR makes 3 changes. It is considered a breaking change to the library.

- This change moves all secrets files into the `config/secrets` folder. This encourages the best practice of isolating secrets in a single place that can be easily removed at build time for projects that may still have secrets in source control.
- The loading of `secrets.json` is restricted to only apply to production environments. Secrets inheritance has been removed to encourage services to keep secrets for different environments fully separate.
- The case of the `NODE_ENV` environment variable is normalized to ensure that `PRODUCTION` and `production` both work as intended.

cc @Raynos @lxe @mlmorg @aegarbutt 