### PR TITLE
Add datacenter support for common.json

### DIFF
--- a/get-config-state.js
+++ b/get-config-state.js
@@ -50,6 +50,10 @@ function getConfigState(dirname, opts) {
             null,
         // load ./config/NODE_ENV.json
         NODE_ENV ? join(configFolder, NODE_ENV + '.json') : null,
+        // load ./config/common.DATACENTER.json
+        dc ?
+          join(configFolder, 'common.' + dc.datacenter + '.json') :
+          null,
         // load ./config/common.json
         join(configFolder, 'common.json'),
         // load defaults

--- a/test/index.js
+++ b/test/index.js
@@ -256,8 +256,16 @@ test('config loads from datacenter file', withFixtures(__dirname, {
             a: 'a',
             b: {
                 c: 'c',
-                d: 'd'
-            }
+                d: 'd',
+                e: 'e'
+            },
+            f: 'f'
+        }),
+        'common.peak1.json': JSON.stringify({
+            b: {
+                e: 'e2'
+            },
+            f: 'f2'
         }),
         'production.json': JSON.stringify({
             b: {
@@ -283,7 +291,9 @@ test('config loads from datacenter file', withFixtures(__dirname, {
     assert.equal(config.get('a'), 'a3');
     assert.equal(config.get('b.c'), 'c2');
     assert.equal(config.get('b.d'), 'd');
-    assert.deepEqual(config.get('b'), { c: 'c2', d: 'd' });
+    assert.equal(config.get('b.e'), 'e2');
+    assert.deepEqual(config.get('b'), { c: 'c2', d: 'd', e: 'e2' });
+    assert.equal(config.get('f'), 'f2');
 
     assert.end();
 }));


### PR DESCRIPTION
Adds support for `common.DATACENTER.json` which is useful to reduce duplication of configuration.

r: @Raynos @lxe @rajeshsegu @malandrew 