### PR TITLE
remove valueOf property from results of config.get()

### DIFF
--- a/get-config-state.js
+++ b/get-config-state.js
@@ -61,6 +61,10 @@ function getConfigState(dirname, opts) {
     // https://github.com/dominictarr/config-chain/issues/14
     var configState = flatten(configTree.store);
 
+    // flattenPrototypes grabs `valueOf` prop from the root prototype
+    // remove it here.
+    delete configState.valueOf;
+
     return configState;
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,13 @@ test('fetchConfig creates a config object', function (assert) {
     assert.end();
 });
 
+test('fetchConfig.get() does not have valueOf key', function (assert) {
+    var config = fetchConfig(__dirname);
+
+    assert.notOk(Object.hasOwnProperty.call(config.get(), 'valueOf'));
+    assert.end();
+});
+
 test('fetchConfig reads from argv', function (assert) {
     var argv = ['--foo', 'bar', '--baz.lulz', 'some value'];
 


### PR DESCRIPTION
Get rid of the annoying `{ valueOf: undefined }` property resulting from prototype flattening.

cc @Raynos 