### PR TITLE
remove entire config extend per get

### DIFF
--- a/config-wrapper.js
+++ b/config-wrapper.js
@@ -4,13 +4,15 @@ var deepExtend = require('deep-extend');
 
 var errors = require('./errors.js');
 
+var safeCloneInto = {value: null};
+var safeCloneFrom = {value: null};
+
 module.exports = ConfigWrapper;
 
 function ConfigWrapper(configObject, loose) {
     var frozen = false;
     // default `loose` to true.
     loose = typeof loose === 'boolean' ? loose : true;
-
 
     return {
         get: configuredGet,
@@ -19,16 +21,15 @@ function ConfigWrapper(configObject, loose) {
     };
 
     function getKey(keyPath) {
-        var clonedObject = deepExtend({}, configObject);
         if (!keyPath) {
-            return clonedObject;
+            return safe(configObject);
         }
 
-        return getPath(clonedObject, keyPath);
+        return safe(getPath(configObject, keyPath));
     }
 
-    function configuredGet(keyPath){
-        if (!keyPath){
+    function configuredGet(keyPath) {
+        if (!keyPath) {
             return getKey();
         }
 
@@ -85,6 +86,12 @@ function ConfigWrapper(configObject, loose) {
         function setEachKey(key) {
             setKey([key], obj[key]);
         }
+    }
+
+    function safe(value) {
+        safeCloneInto.value = null;
+        safeCloneFrom.value = value;
+        return deepExtend(safeCloneInto, safeCloneFrom).value;
     }
 }
 


### PR DESCRIPTION
It seems that we currently deep clone the entire config for each get. This is clearly suboptimal in cases with large config. I have written a safe function which extends the returned subset only. I would consider removing this feature all together in future, however this is a reasonable non-breaking patch.

cc: @Raynos 